### PR TITLE
Splitter - split the state inventories & add IN/IA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 
 # scipiper specific ignores:
 .remake/
+1_fetch/tmp/*
+!1_fetch/tmp/state_splits.yml
 3_visualize/out/

--- a/123_state_tasks.R
+++ b/123_state_tasks.R
@@ -1,5 +1,8 @@
 do_state_tasks <- function(oldest_active_sites, ...) {
 
+  split_inventory(summary_file='1_fetch/tmp/state_splits.yml',
+                  sites_info=oldest_active_sites)
+
   # Define task table rows
   state_abbv <- oldest_active_sites$state_cd
 
@@ -10,7 +13,7 @@ do_state_tasks <- function(oldest_active_sites, ...) {
       sprintf("%s_data", task_name)
     },
     command = function(..., task_name) {
-      sprintf("get_site_data(sites_info=oldest_active_sites, state=I('%s'), parameter=parameter)", task_name)
+      sprintf("get_site_data(state_info_file='1_fetch/tmp/inventory_%s.tsv', parameter=parameter)", task_name)
     }
   )
 
@@ -35,4 +38,24 @@ do_state_tasks <- function(oldest_active_sites, ...) {
 
   # Return nothing to the parent remake file
   return()
+}
+
+split_inventory <- function(
+  summary_file='1_fetch/tmp/state_splits.yml',
+  sites_info=oldest_active_sites) {
+
+  if(!dir.exists('1_fetch/tmp')) dir.create('1_fetch/tmp')
+
+  # Loop over states and save info to separate files
+  split_files <- purrr::map(sites_info$state_cd, function(state) {
+    state_fn <- sprintf("1_fetch/tmp/inventory_%s.tsv", state)
+    readr::write_tsv(
+      filter(sites_info, state_cd == state),
+      path = state_fn)
+    return(state_fn)
+  }) %>%
+    purrr::reduce(c) %>%
+    sort()
+
+  sc_indicate(ind_file = summary_file, data_file = split_files)
 }

--- a/123_state_tasks.yml
+++ b/123_state_tasks.yml
@@ -29,20 +29,20 @@ targets:
   # --- WI --- #
   
   WI_data:
-    command: get_site_data(sites_info=oldest_active_sites, state=I('WI'), parameter=parameter)
+    command: get_site_data(state_info_file='1_fetch/tmp/inventory_WI.tsv', parameter=parameter)
 
   # --- MN --- #
   
   MN_data:
-    command: get_site_data(sites_info=oldest_active_sites, state=I('MN'), parameter=parameter)
+    command: get_site_data(state_info_file='1_fetch/tmp/inventory_MN.tsv', parameter=parameter)
 
   # --- MI --- #
   
   MI_data:
-    command: get_site_data(sites_info=oldest_active_sites, state=I('MI'), parameter=parameter)
+    command: get_site_data(state_info_file='1_fetch/tmp/inventory_MI.tsv', parameter=parameter)
 
   # --- IL --- #
   
   IL_data:
-    command: get_site_data(sites_info=oldest_active_sites, state=I('IL'), parameter=parameter)
+    command: get_site_data(state_info_file='1_fetch/tmp/inventory_IL.tsv', parameter=parameter)
 

--- a/123_state_tasks.yml
+++ b/123_state_tasks.yml
@@ -25,6 +25,8 @@ targets:
       - MN_data
       - MI_data
       - IL_data
+      - IN_data
+      - IA_data
 
   # --- WI --- #
   
@@ -45,4 +47,14 @@ targets:
   
   IL_data:
     command: get_site_data(state_info_file='1_fetch/tmp/inventory_IL.tsv', parameter=parameter)
+
+  # --- IN --- #
+  
+  IN_data:
+    command: get_site_data(state_info_file='1_fetch/tmp/inventory_IN.tsv', parameter=parameter)
+
+  # --- IA --- #
+  
+  IA_data:
+    command: get_site_data(state_info_file='1_fetch/tmp/inventory_IA.tsv', parameter=parameter)
 

--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,7 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(state_info_file, parameter) {
+  site_info <- readr::read_tsv(state_info_file, col_types='cccddcDDi')
   message(sprintf('  Retrieving data for %s-%s', site_info$state_cd, site_info$site_no))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/1_fetch/tmp/state_splits.yml
+++ b/1_fetch/tmp/state_splits.yml
@@ -1,0 +1,7 @@
+1_fetch/tmp/inventory_IA.tsv: c24ec96cadd72dfc2ceff4b43d3c36ec
+1_fetch/tmp/inventory_IL.tsv: a6a21df129682a8eee05359b8ba98d06
+1_fetch/tmp/inventory_IN.tsv: ecd94822d66a07024e5f0d0e49dd8407
+1_fetch/tmp/inventory_MI.tsv: fa1f21d2cb6665c4e67e9cd9fbe78c7d
+1_fetch/tmp/inventory_MN.tsv: 58edc57629f477d946b5de66245f709f
+1_fetch/tmp/inventory_WI.tsv: a59a7482d798f017aaa358e462f9ffc7
+

--- a/remake.yml
+++ b/remake.yml
@@ -22,7 +22,7 @@ targets:
 
   # Configuration
   states:
-    command: c(I(c('WI','MN','MI', 'IL')))
+    command: c(I(c('WI','MN','MI', 'IL', 'IN', 'IA')))
   parameter:
     command: c(I('00060'))
 


### PR DESCRIPTION
Split the state inventories outside of the `get_site_data` fxn so that we don't re-download states that we have already downloaded. Then, add IN and IA to `states` and verify that it only downloads those two states data.

Targets that rebuilt after adding IN/IA:
- `states`
- `oldest_active_sites`
- `state_tasks`
- `IN_data`
- `IA_data`
- `3_visualize/out/site_map.png`